### PR TITLE
docs: fix 'edit this page' links

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -44,9 +44,9 @@ const config: ThemeConfig = {
 			</span>
 		</div>
 	),
-	docsRepositoryBase: 'https://github.com/teraihq/terai',
+	docsRepositoryBase: 'https://github.com/terai-labs/terai/tree/master/website',
 	project: {
-		link: 'https://github.com/teraihq/terai'
+		link: 'https://github.com/terai-labs/terai'
 	},
 	toc: {
 		backToTop: true
@@ -65,7 +65,7 @@ const config: ThemeConfig = {
 			<span>
 				MIT {new Date().getFullYear()} ©{' '}
 				<a
-					href='https://github.com/teraihq/terai'
+					href='https://github.com/terai-labs/terai'
 					target='_blank'
 					rel='noreferrer'
 				>


### PR DESCRIPTION
## 📝 Description
updates the theme.config.tsx project metadata such that the "Edit this page" links go to the correct place.

also updates to the current repository owner/name, rather than relying on a redirect from the old name.

## ⛳️ Current behavior (updates)
currently the links go to `https://github.com/teraihq/terai/src/pages/docs/references/cli.mdx` which is incorrect.

## 🚀 New behavior
links will go to the correct page source file.

## 💣 Is this a breaking change (Yes/No)
N/A
